### PR TITLE
Guard bg[i] from being null in render BG graph

### DIFF
--- a/scripts/status.js
+++ b/scripts/status.js
@@ -100,18 +100,20 @@ var date = new Date();
 var zerotime = date.getTime() - ((numBGs * 5) * 600);
 var zero_x = numBGs + 5;
 for (var i = 0; i <= numBGs; i++) {
-    var x = 2 + zero_x + Math.round(((((bg[i].date - zerotime)/1000)/60)/5));
-    var y = Math.round( 21 - ( ( bg[i].glucose - 250 ) / 8 ) );
-    //left and right boundaries
-    if ( x < 5 ) x = 5;
-    if ( x > 127 ) x = 127;
-    //upper and lower boundaries
-    if ( y < 21 ) y = 21;
-    if ( y > 51 ) y = 51;
-    display.oled.drawPixel([x, y, 1]);
-    // if we have multiple data points within 3m, look further back to fill in the graph
-    if ( bg[i-1] && bg[i-1].date - bg[i].date < 200000 ) {
-        numBGs++;
+    if (bg[i] != null) {
+        var x = 2 + zero_x + Math.round(((((bg[i].date - zerotime)/1000)/60)/5));
+        var y = Math.round( 21 - ( ( bg[i].glucose - 250 ) / 8 ) );
+        //left and right boundaries
+        if ( x < 5 ) x = 5;
+        if ( x > 127 ) x = 127;
+        //upper and lower boundaries
+        if ( y < 21 ) y = 21;
+        if ( y > 51 ) y = 51;
+        display.oled.drawPixel([x, y, 1]);
+        // if we have multiple data points within 3m, look further back to fill in the graph
+        if ( bg[i-1] && bg[i-1].date - bg[i].date < 200000 ) {
+            numBGs++;
+        }
     }
 }
 

--- a/scripts/status.js
+++ b/scripts/status.js
@@ -99,7 +99,7 @@ var numBGs = (suggested.predBGs != undefined) ? (72) : (120); //fill the whole g
 var date = new Date();
 var zerotime = date.getTime() - ((numBGs * 5) * 600);
 var zero_x = numBGs + 5;
-for (var i = 0; i <= numBGs; i++) {
+for (var i = 0; i < numBGs; i++) {
     if (bg[i] != null) {
         var x = 2 + zero_x + Math.round(((((bg[i].date - zerotime)/1000)/60)/5));
         var y = Math.round( 21 - ( ( bg[i].glucose - 250 ) / 8 ) );


### PR DESCRIPTION
I was getting this error during looping and it would stop the loop:

```
/root/src/openaps-menu/scripts/status.js:103
    var x = 2 + zero_x + Math.round(((((bg[i].date - zerotime)/1000)/60)/5));
                                              ^

TypeError: Cannot read property 'date' of undefined
    at Object.<anonymous> (/root/src/openaps-menu/scripts/status.js:103:47)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Function.Module.runMain (module.js:693:10)
    at startup (bootstrap_node.js:188:16)
    at bootstrap_node.js:609:3
```

This led me to believe that one of the items in the array is null, so this skips that loop iteration. After doing this the loop was running properly again.