### PR TITLE
Prevent Nightscout from crashing if {} returned

### DIFF
--- a/scripts/getvoltage.sh
+++ b/scripts/getvoltage.sh
@@ -2,6 +2,7 @@
 
 command -v socat >/dev/null 2>&1 || { echo >&2 "I require socat but it's not installed. Aborting."; exit 1; }
 
+[[ $RESPONSE == "{}" ]] && unset RESPONSE
 RESPONSE=`echo '{"command":"read_voltage"}' | socat -,ignoreeof ~/src/openaps-menu/socket-server.sock | sed -n 's/.*"response":\([^}]*\)}/\1/p'`
 [[ $RESPONSE = *[![:space:]]* ]] && echo $RESPONSE
 #./getvoltage.sh | sed -n 's/.*"response":\([^}]*\)}/\1/p'


### PR DESCRIPTION
Added one line to check content of $RESPONSE for emptyness (=~ {}) and unset $RESPONSE, so error correction through OR in next line applies.